### PR TITLE
Bullet proof Write against empty writes.

### DIFF
--- a/stream/streaming_bytes_writer.go
+++ b/stream/streaming_bytes_writer.go
@@ -15,6 +15,9 @@ func newStreamingBytesWriter(
 }
 
 func (s *streamingBytesWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if err := s.streamingBytesServer.Send(
 		&google_protobuf.BytesValue{
 			Value: p,


### PR DESCRIPTION
Ran in to this using `WriteToStreamingBytesServer` seems like `bufio.WriteTo` can send empty writes which is, kinda dumb.
It was tripping up the library though because it would send an empty rpc which gets interpreted as `io.EOF` on the other end.